### PR TITLE
Update imgSequence.js

### DIFF
--- a/imgSequence.js
+++ b/imgSequence.js
@@ -25,6 +25,7 @@ gsap.to(unis, {
   // duration: 1,
   scrollTrigger: {
     trigger: section,
+    fastScrollEnd: true,
     pin: true,
     start: -5,
     scrub: true,


### PR DESCRIPTION
if the scroll speed is high, the animation will stop in order not to overlap with the content below